### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,5 +5,5 @@ A portable and extensible Common Lisp pretty printer.
 |---------+--------------------------------------------------------------------------------------------|
 | source  | git:https://github.com/s-expressionists/Inravina.git                                       |
 | commit  | 85dfc7e                                                                                    |
-| systems | inravina inravina-shim inravina-shim/text inravina-native inravina-intrinsic inravina-extrinsic inravina-examples |
+| systems | inravina inravina-shim inravina-native inravina-intrinsic inravina-extrinsic inravina-examples |
 |---------+--------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Remove inravina-shim/text. Probably was a typo for inravina-shim/test which has been removed from the asd.